### PR TITLE
Fix Content Default Access setting getting lost in group settings

### DIFF
--- a/lib/events.php
+++ b/lib/events.php
@@ -38,13 +38,5 @@ function group_ux_pagesetup() {
  * @param type $object
  */
 function group_ux_default_permissions_hook($event, $type, $object) {
-  $default_permission = get_input('group_ux_default_permission');
-  
-  if ($default_permission == 'group_acl') {
-	$default_permission = $object->group_acl;
-  }
-  
-  if (is_numeric($default_permission)) {
-	$object->group_ux_default_permission = $default_permission;
-  }
+  $object->group_ux_default_permission = get_input('group_ux_default_permission');
 }


### PR DESCRIPTION
When setting the Content Default Access to “Group members only” or “User
default access”, when accessing the group settings again, the setting
was displayed as “Private”. “User default access” as a setting was not
working at all.

This patch fixes the issue.
